### PR TITLE
fix: freeze fiberplane-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
 name = "catnip-provider"
 version = "1.0.0"
 dependencies = [
+ "fiberplane-models",
  "fiberplane-pdk",
  "serde",
  "serde-aux",
@@ -224,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-models"
-version = "1.0.0-alpha.3"
+version = "1.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2435d8ba48dc8135191a072e254584b2cc35cbf8b758240e7e766404ca225461"
+checksum = "681b60729c95b24bb10f2b689b1794537760872c35bd569cbe429ad73e8f4e90"
 dependencies = [
  "base64",
  "base64uuid",
@@ -246,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk"
-version = "1.0.0-alpha.3"
+version = "1.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e9080fa4edd479221379adde67f6063e2b741e6f37d4967e67a67213d1acec"
+checksum = "a93d881e40979960e897e74a564d828ca824ce62db9087d09858aceba0e22f0c"
 dependencies = [
  "fiberplane-models",
  "fiberplane-pdk-macros",
@@ -264,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-pdk-macros"
-version = "1.0.0-alpha.3"
+version = "1.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1896927520e0a40d5be3dba5b89b1e60a9bf7fe09b1eb2f144511285ec0b0166"
+checksum = "d75dcb997960561606951be1b97a28cea20550610178236638ce56467e391cd4"
 dependencies = [
  "Inflector",
  "fiberplane-models",
@@ -278,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "fiberplane-provider-bindings"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd9698f1722d879d216330eb04cf5abc810437c3cc18cdb919ebb47cf8c9b75"
+checksum = "fa52df4dc94847446275d1a5d0358df462b09dba546e0585342401673303f2cb"
 dependencies = [
  "bytes",
  "fiberplane-models",
@@ -310,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "fp-bindgen"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68001df5b79fae975469931d0d003d23da9122902c7abee675958edac2926133"
+checksum = "b744e2a1f5bfd3e75983abddb8cfe59179a573be3f672b2755f0a25aec8660d7"
 dependencies = [
  "Inflector",
  "bytes",
@@ -330,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "fp-bindgen-macros"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82c18058cae910e8ed8295193165a3cff05611101e7983458f1c27ad585742"
+checksum = "42a0086f6f4c63aca5b1b9447ee0470141d8ed1ce268430328395324e552363c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -342,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "fp-bindgen-support"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeb4e810c1608a653380d5c875114fa1e00f4c05b2907677d2d1f5016861282"
+checksum = "d0215a44a7cd16a69a5b7e93802a8ccd83e7f6d84cd464fbdabb604770daf087"
 dependencies = [
  "fp-bindgen-macros",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,12 @@ version = "1.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-fiberplane-pdk = { version = "1.0.0-alpha.3" }
+# The current PDK beta only works with this exact version of
+# the fiberplane-models crate, this dependency is added to pin
+# fiberplane-models version even if it's not directly imported in
+# code.
+fiberplane-models = { version = "=1.0.0-beta.1" }
+fiberplane-pdk = { version = "=1.0.0-beta.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-aux = "4.1"


### PR DESCRIPTION
The CI of https://github.com/fiberplane/fiberplane will publish breaking
changes as beta or alpha versions without any warning, breaking
downstream packages that rely on Cargo's default version resolution.

Stricter version requirement in the project will work around this.
